### PR TITLE
Made the require_relative rule less strict

### DIFF
--- a/lib/foodcritic/rules/rules.rb
+++ b/lib/foodcritic/rules/rules.rb
@@ -162,7 +162,9 @@ rule 'DAPTIV001', 'Missing .tailor file. All cookbooks should comply with style 
 end
 
 rule 'DAPTIV002', 'Prefer include_attribute syntax to require_relative.' do
-  recipe do |ast|
-    ast.xpath('//command[ident/@value="require_relative"]')
+  recipe do |ast, path|
+    if path.include?('recipes') || path.include?('attributes')
+      ast.xpath('//command[ident/@value="require_relative"]')
+    end
   end
 end


### PR DESCRIPTION
Previously the rule disallow any use of require_relative in a cookbook
